### PR TITLE
Added UpsertScopeAsync and test

### DIFF
--- a/src/GeekLearning.Authorizations/IAuthorizationsManager.cs
+++ b/src/GeekLearning.Authorizations/IAuthorizationsManager.cs
@@ -9,6 +9,8 @@
     {
         Task CreateScopeAsync(string scopeName, string description, params string[] parents);
 
+        Task UpsertScopeAsync(string scopeName, string description, params string[] parents);
+
         Task DeleteScopeAsync(string scopeName);
 
         Task LinkScopeAsync(string parentScopeName, string childScopeName);

--- a/tests/GeekLearning.Authorizations.Tests/ScopeTests.cs
+++ b/tests/GeekLearning.Authorizations.Tests/ScopeTests.cs
@@ -25,6 +25,14 @@
 
                 await authorizationsFixture.Context.SaveChangesAsync();
 
+                await authorizationsFixture.AuthorizationsManager
+                                            .CreateScopeAsync(
+                                                "scope1",
+                                                "Description scope 1",
+                                                new string[] { "scopeParent1", "scopeParent2" });
+
+                await authorizationsFixture.Context.SaveChangesAsync();
+
                 var scope = authorizationsFixture.Context.Scopes()
                                                          .Include(r => r.Parents)
                                                          .Include(r => r.Children)


### PR DESCRIPTION
Currently, only Create and Delete have been implemented.
In case it's necessary to update scope description, it wouldn't have any way of doing it.

Added UpsertScopeAsync and test case.